### PR TITLE
Include patches to make paragraphs play nice with layout builder, and…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,14 @@
         "patchLevel": {
             "drupal/core": "-p2"
         },
-        "patches": []
+        "patches": {
+            "drupal/paragraphs": {
+                "Issue #2901390: Integrity constraint violation: 1048 Column 'langcode' cannot be null:": "https://www.drupal.org/files/issues/2019-07-10/paragraphs-set_langcode_widgets-2901390-29.patch"
+            },
+            "drupal/rabbit_hole": {
+                "Issue #3066541: Do not add Rabbit Hole fields to Layout Builder form.": "https://www.drupal.org/files/issues/2019-07-08/3066541-2.patch"
+            }
+        }
     },
     "repositories": {
         "drupal": {


### PR DESCRIPTION
I'm back-porting a couple of patches that we added to Verizon. One makes sure that paragraphs plays nice with layout builder (prevents a nasty error upon save), and the other hides the rabbit hole settings on the layout builder screen.