### PR TITLE
BW-59: Enviornment Indicator module update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "drupal/contact_storage": "^1.0@beta",
         "drupal/devel": "^2.0",
         "drupal/entity_reference_revisions": "^1.6",
-        "drupal/environment_indicator": "^3.6",
+        "drupal/environment_indicator": "^4.0",
         "drupal/field_group": "^3.0",
         "drupal/google_tag": "^1.1",
         "drupal/layout_builder_modal": "^1.0@alpha",


### PR DESCRIPTION
Steps taken:
- Identified that the Kettering composer.json file was pulling in a version of envirorment_indicator from duo_starter that did not support d9 
- Found there was a branch on duo_starter that provided this d9 support
- Checking in with this PR to see if it is possible to merge this branch in

Test instructions:
- Verify d9 support with the following command if merged: composer why drupal/core | grep -Ev "\^9"

Next steps:
- If merged report back to my team and move forward with the ticket 

Jira ticket:
[KET-282](https://codeandtheory.atlassian.net/secure/RapidBoard.jspa?rapidView=967&projectKey=KET&modal=detail&selectedIssue=KET-282)