### PR TITLE
WIP KET-284 branch for testing linkit d9 support upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "drupal/google_tag": "^1.1",
         "drupal/layout_builder_modal": "^1.0@alpha",
         "drupal/layout_builder_restrictions": "^2.2",
-        "drupal/linkit": "^4.3",
+        "drupal/linkit": "^6.0@beta",
         "drupal/media_library_theme_reset": "1.0-beta1",
         "drupal/metatag": "^1.8",
         "drupal/paragraphs": "^1.9",


### PR DESCRIPTION
Steps taken:

- Updated the composer.json file to point to a d9 ready branch 
- Tested for stability and regressions on the Kettering website 

Test instructions:
- Ensure the d9 compatible version of the module is successfully installed on Kettering 

Next steps:
- Check for regressions on all sites currently using duo_starter
Jira ticket:
[KET-284](https://codeandtheory.atlassian.net/secure/RapidBoard.jspa?rapidView=967&view=detail&selectedIssue=KET-284)
